### PR TITLE
Fix empty target error when installing via SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,6 @@ let package = Package(name: "SDDownloadManager",
                       products: [.library(name: "SDDownloadManager",
                                           targets: ["SDDownloadManager"])],
                       targets: [.target(name: "SDDownloadManager",
-                                        path: "SDDownloadManager/Classes", sources:["SDDownloadManager/Classes"]),
+                                        path: "SDDownloadManager/Classes"),
                                 ]
                       )


### PR DESCRIPTION
Remove empty target sources field (can't be a directory apparently) in Package.swift to fix:

Invalid Source '/Users/user/Documents/GitHub/SDDownloadManager/SDDownloadManager/Classes/SDDownloadManager/Classes': File not found.Source files for target SDDownloadManager should be located under /Users/user/Documents/GitHub/SDDownloadManager/SDDownloadManager/Classestarget 'SDDownloadManager' referenced in product 'SDDownloadManager' is empty